### PR TITLE
feature: add sample weight support

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,15 @@ print(f"Trimmed mean: {digest.trimmed_mean(0.1, 0.9)}")
 
 ### Updating a TDigest
 
-Use `batch_update` to merge a sequence of many values at once, or `update` to add one value at a time:
+Use `batch_update` to merge a sequence of many values at once, or `update` to add one value at a time.
+Both methods accept optional weights:
 
 ```python
 digest = TDigest()
 digest.batch_update([0, 1, 2])
 digest.update(3)
+digest.update(3, weight=2.5)
+digest.batch_update([4, 5], weights=[1.0, 0.5])
 ```
 
 Note: These methods are *not* the same - they are optimized for different use-cases, and there can be significant performance differences.

--- a/fastdigest.pyi
+++ b/fastdigest.pyi
@@ -33,12 +33,17 @@ class TDigest:
 
     @staticmethod
     def from_values(
-        values: Sequence[Union[float, int]], max_centroids: int = 1000
+        values: Sequence[Union[float, int]],
+        weights: Optional[Sequence[Union[float, int]]] = None,
+        max_centroids: int = 1000,
     ) -> "TDigest":
         """
         Create a new TDigest of a sequence of numerical values.
 
         :param values: Sequence of float or int values.
+        :param weights:
+            Optional sequence of weights. If provided, it must have the same
+            length as `values`.
         :param max_centroids:
             Number of centroids to maintain. A lower value enables a
             smaller memory footprint and faster computation speed at the
@@ -119,7 +124,11 @@ class TDigest:
         """
         ...
 
-    def batch_update(self, values: Sequence[Union[float, int]]) -> None:
+    def batch_update(
+        self,
+        values: Sequence[Union[float, int]],
+        weights: Optional[Sequence[Union[float, int]]] = None,
+    ) -> None:
         """
         Update the TDigest in-place with a sequence of numbers.
 
@@ -127,10 +136,13 @@ class TDigest:
         `update` in most cases.
 
         :param values: Sequence of values to add.
+        :param weights:
+            Optional sequence of weights. If provided, it must have the same
+            length as `values`.
         """
         ...
 
-    def update(self, value: Union[float, int]) -> None:
+    def update(self, value: Union[float, int], weight: float = 1.0) -> None:
         """
         Update the TDigest in-place with a single value.
 
@@ -139,6 +151,7 @@ class TDigest:
         add one observed value at a time, e.g. in streaming applications.
 
         :param value: Single value to add.
+        :param weight: Optional weight for the value (default is 1.0 for backward compatibility).
         """
         ...
 

--- a/tests/test_tdigest.py
+++ b/tests/test_tdigest.py
@@ -236,6 +236,48 @@ def test_updates(
 
 
 # -------------------------------------------------------------------
+# Weighted update tests
+# -------------------------------------------------------------------
+def test_weighted_update_mean_sum() -> None:
+    d = TDigest()
+    d.update(10, weight=2)
+    d.update(0, weight=1)
+    d.update(5, weight=0)  # weight zero, should have no effect
+    assert d.n_values == 3
+    assert math.isclose(d.sum(), 20.0, rel_tol=RTOL, abs_tol=ATOL)
+    assert math.isclose(d.mean(), 20.0 / 3.0, rel_tol=RTOL, abs_tol=ATOL)
+    assert math.isclose(d.min(), 0.0, rel_tol=RTOL, abs_tol=EPS)
+    assert math.isclose(d.max(), 10.0, rel_tol=RTOL, abs_tol=EPS)
+
+
+def test_weighted_batch_update_and_from_values() -> None:
+    d1 = TDigest()
+    d1.batch_update([1, 2, 3], weights=[1, 2, 3])
+    assert d1.n_values == 6
+    assert math.isclose(d1.sum(), 14.0, rel_tol=RTOL, abs_tol=ATOL)
+    assert math.isclose(d1.mean(), 14.0 / 6.0, rel_tol=RTOL, abs_tol=ATOL)
+    d2 = TDigest.from_values([1, 2, 3], weights=[1, 2, 3])
+    assert d2.n_values == 6
+    assert math.isclose(d2.sum(), 14.0, rel_tol=RTOL, abs_tol=ATOL)
+    assert math.isclose(d2.mean(), 14.0 / 6.0, rel_tol=RTOL, abs_tol=ATOL)
+    assert d1 == d2, "Produced TDigest instances should be equal"
+
+
+def test_weight_validation() -> None:
+    d = TDigest()
+    with pytest.raises(ValueError):
+        d.update(1, weight=-1)
+    with pytest.raises(ValueError):
+        d.batch_update([1, 2], weights=[1])
+    with pytest.raises(ValueError):
+        d.batch_update([1], weights=[-1])
+    with pytest.raises(ValueError):
+        TDigest.from_values([1], weights=[-1])
+    with pytest.raises(ValueError):
+        TDigest.from_values([1, 2], weights=[1])
+
+
+# -------------------------------------------------------------------
 # Quantile tests (quantile, percentile, median, iqr, min, max)
 # -------------------------------------------------------------------
 def test_quantile_median_min_max(empty_digest: TDigest) -> None:


### PR DESCRIPTION
### Description

As mentioned in [respective feature request](https://github.com/moritzmucha/fastdigest/issues/3) it would be great to have an API and feature set aligned with existing implementation (e.g. as [`pytdigest`](https://github.com/protivinsky/pytdigest/)), so adding an option of weighted updates would be helpful.

Here I introduce optional, backward-compatible (in both calculations and serialization/deserialization, as it shouldn't affect saved/restored state) `weight` argument to support single `weight` >= 0 for `.update` and an iterable `weights` argument for `.from_values` and `.batch_update` methods)

### Changes
- Updated Rust implementation (inspired by `pytdigest`, just used `weights` instead of `w` for argument name, we can opt for `w` name to unify `weight`/`weights` usage)
- Added respective unit tests
- Updated API and README files to reflect changes (`weight` argument)

### Notes
- I used ruff to check and format .pyi file, haven't really formatted .rs files
- I didn't make extensive testing, however, all the tests (existing + basic new) pass, also my own routines (I used `pytdigest` with weights for work and now switched to local fork of your repo with implemented weights) are passing and are equal up to a rounding factor.
@jasonkena, JFYI, if you can also test it on your use case, that would be great